### PR TITLE
Fix verify token expiration

### DIFF
--- a/src/main/java/fr/erwil/Spricture/Configuration/Security/JWT/JwtTokenProviderImpl.java
+++ b/src/main/java/fr/erwil/Spricture/Configuration/Security/JWT/JwtTokenProviderImpl.java
@@ -25,7 +25,7 @@ public class JwtTokenProviderImpl implements IJwtTokenProvider {
     public JwtTokenProviderImpl(SecurityJwtProperties properties) {
         this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(properties.getSecretKey()));
         this.loginExpirationMilliseconds = properties.getLoginExpirationMilliseconds();
-        this.verifyExpirationMilliseconds = properties.getLoginExpirationMilliseconds();
+        this.verifyExpirationMilliseconds = properties.getValidateExpirationMilliseconds();
 
     }
 


### PR DESCRIPTION
## Summary
- read JWT expiry values from proper property

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6840033c5bec832ba003e945b5be891c