### PR TITLE
Implement MediumStat full storage usage

### DIFF
--- a/application.properties.example
+++ b/application.properties.example
@@ -40,3 +40,9 @@ storage.s3.accessKey=__REPLACE_ME__
 storage.s3.secretKey=__REPLACE_ME__
 storage.s3.bucket=photone-dev
 
+# Medium Stat APP user configuration
+medium.stat.app-pseudo=APP_STAT
+medium.stat.app-password=changeme
+medium.stat.app-email=app_stat@example.com
+medium.stat.app-quota=10
+

--- a/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/AppStatUserInitializer.java
+++ b/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/AppStatUserInitializer.java
@@ -1,0 +1,47 @@
+package fr.erwil.Spricture.Application.Medium.MediumStat;
+
+import fr.erwil.Spricture.Application.User.IUserRepository;
+import fr.erwil.Spricture.Application.User.User;
+import fr.erwil.Spricture.Application.User.UserStatus;
+import fr.erwil.Spricture.Configuration.Security.Utils.EncryptionUtils;
+import jakarta.transaction.Transactional;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppStatUserInitializer implements CommandLineRunner {
+
+    private final IUserRepository userRepository;
+    private final IMediumStatService mediumStatService;
+    private final PasswordEncoder passwordEncoder;
+    private final MediumStatProperties properties;
+
+    public AppStatUserInitializer(IUserRepository userRepository,
+                                  IMediumStatService mediumStatService,
+                                  PasswordEncoder passwordEncoder,
+                                  MediumStatProperties properties) {
+        this.userRepository = userRepository;
+        this.mediumStatService = mediumStatService;
+        this.passwordEncoder = passwordEncoder;
+        this.properties = properties;
+    }
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        userRepository.findByPseudo(properties.getAppPseudo()).orElseGet(() -> {
+            User user = User.builder()
+                    .pseudo(properties.getAppPseudo())
+                    .email(properties.getAppEmail())
+                    .password(passwordEncoder.encode(properties.getAppPassword()))
+                    .salt(EncryptionUtils.generateSalt())
+                    .storageQuota(properties.getAppQuota())
+                    .build();
+            user.setStatus(UserStatus.BLOCKED_BY_ADMIN);
+            User created = userRepository.save(user);
+            mediumStatService.create(created.getId());
+            return created;
+        });
+    }
+}

--- a/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/IMediumStatRepository.java
+++ b/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/IMediumStatRepository.java
@@ -1,10 +1,8 @@
 package fr.erwil.Spricture.Application.Medium.MediumStat;
 
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 
 import java.util.Optional;
 
@@ -12,5 +10,8 @@ public interface IMediumStatRepository extends JpaRepository<MediumStat, Long> {
     Optional<MediumStat> findByUser_Id(Long userId);
     @Query("SELECT SUM(m.storageUsage) FROM MediumStat m WHERE m.user.id = :userId")
     Optional<Long> sumStorageUsageByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT SUM(m.storageUsage) FROM MediumStat m WHERE m.user.id <> :userId")
+    Optional<Long> sumStorageUsageExceptUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/MediumStatProperties.java
+++ b/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/MediumStatProperties.java
@@ -1,0 +1,16 @@
+package fr.erwil.Spricture.Application.Medium.MediumStat;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "medium.stat")
+public class MediumStatProperties {
+    private String appPseudo = "APP_STAT";
+    private String appEmail = "app_stat@spricture.local";
+    private String appPassword = "app_stat";
+    // quota in GO
+    private long appQuota = 10L;
+}


### PR DESCRIPTION
## Summary
- add MediumStatProperties to configure APP_STAT user
- create AppStatUserInitializer to create APP_STAT user on startup
- implement global usage calculation in MediumStatService
- add repository query for total usage excluding APP_STAT
- document properties in example config
- address review comments

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684330b44ef0832b87280ee37ec8861d