### PR TITLE
Keep APP_STAT user when seeding

### DIFF
--- a/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/MediumStatProperties.java
+++ b/src/main/java/fr/erwil/Spricture/Application/Medium/MediumStat/MediumStatProperties.java
@@ -1,0 +1,14 @@
+package fr.erwil.Spricture.Application.Medium.MediumStat;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "medium.stat")
+public class MediumStatProperties {
+    private String appPseudo = "APP_STAT";
+}

--- a/src/main/java/fr/erwil/Spricture/Application/User/IUserRepository.java
+++ b/src/main/java/fr/erwil/Spricture/Application/User/IUserRepository.java
@@ -8,4 +8,6 @@ public interface IUserRepository extends JpaRepository<User, Long> {
     Optional<User> findByPseudo(String pseudo);
     Optional<User> findByEmail(String email);
 
+    void deleteByPseudoNot(String pseudo);
+
 }

--- a/src/main/java/fr/erwil/Spricture/Application/User/Seeding/UserSeeder.java
+++ b/src/main/java/fr/erwil/Spricture/Application/User/Seeding/UserSeeder.java
@@ -1,6 +1,7 @@
 package fr.erwil.Spricture.Application.User.Seeding;
 
 import fr.erwil.Spricture.Application.User.IUserRepository;
+import fr.erwil.Spricture.Application.Medium.MediumStat.MediumStatProperties;
 import fr.erwil.Spricture.Configuration.Data.Seeding.ISeeder;
 import org.springframework.stereotype.Component;
 
@@ -9,15 +10,17 @@ public class UserSeeder implements ISeeder {
 
     private final IUserRepository userRepository;
     private final UserFactory userFactory;
+    private final MediumStatProperties properties;
 
-    public UserSeeder(IUserRepository userRepository, UserFactory userFactory) {
+    public UserSeeder(IUserRepository userRepository, UserFactory userFactory, MediumStatProperties properties) {
         this.userRepository = userRepository;
         this.userFactory = userFactory;
+        this.properties = properties;
     }
 
     @Override
     public void seed() {
-        userRepository.deleteAll();
+        userRepository.deleteByPseudoNot(properties.getAppPseudo());
 
         userRepository.save(userFactory.getAdminUser());
         userRepository.save(userFactory.getUserUser());


### PR DESCRIPTION
## Summary
- add repository method to delete all but a specific pseudo
- add MediumStatProperties for the APP_STAT pseudo
- keep APP_STAT user in the user seeder

## Testing
- `bash mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68434695e964832bad71fe977c7ea5a0