### PR TITLE
Update user seeding configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,5 @@ build/
 
 ### VS Code ###
 .vscode/
-/src/main/resources/application.properties
 /photos/
 /uploads/
-application.properties

--- a/application.properties.example
+++ b/application.properties.example
@@ -47,3 +47,9 @@ medium.stat.app-email=app_stat@example.com
 medium.stat.app-quota=10
 medium.stat.quota-threshold-percent=90
 
+# User seeding configuration
+# If passwords are left empty, random strong passwords will be generated
+user.seed.admin-email=admin@example.com
+user.seed.admin-password=
+user.seed.default-password=
+

--- a/src/main/java/fr/erwil/Spricture/Application/User/Seeding/UserFactory.java
+++ b/src/main/java/fr/erwil/Spricture/Application/User/Seeding/UserFactory.java
@@ -7,6 +7,8 @@ import fr.erwil.Spricture.Configuration.Security.Utils.EncryptionUtils;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import fr.erwil.Spricture.Application.User.Seeding.UserSeedProperties;
+
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
@@ -15,9 +17,11 @@ import java.util.stream.IntStream;
 public class UserFactory implements IUserFactory {
 
     private final PasswordEncoder passwordEncoder;
+    private final UserSeedProperties seedProperties;
 
-    public UserFactory(PasswordEncoder passwordEncoder) {
+    public UserFactory(PasswordEncoder passwordEncoder, UserSeedProperties seedProperties) {
         this.passwordEncoder = passwordEncoder;
+        this.seedProperties = seedProperties;
     }
 
     @Override
@@ -26,8 +30,8 @@ public class UserFactory implements IUserFactory {
                 .pseudo("UserAdmin")
                 .name("Administrator")
                 .lastName("LastName")
-                .email("admin@company.com")
-                .password(passwordEncoder.encode("admin"))
+                .email(seedProperties.getAdminEmail())
+                .password(passwordEncoder.encode(seedProperties.getAdminPassword()))
                 .role(UserRole.ROLE_ADMIN)
                 .salt(EncryptionUtils.generateSalt())
                 .storageQuota(2L)
@@ -43,7 +47,7 @@ public class UserFactory implements IUserFactory {
                 .name("User")
                 .lastName("LastName")
                 .email("user@company.com")
-                .password(passwordEncoder.encode("user"))
+                .password(passwordEncoder.encode(seedProperties.getDefaultPassword()))
                 .role(UserRole.ROLE_USER)
                 .salt(EncryptionUtils.generateSalt())
                 .storageQuota(1L)
@@ -65,7 +69,7 @@ public class UserFactory implements IUserFactory {
                 .name("Random")
                 .lastName("User")
                 .email("random_" + uuid + "@example.com")
-                .password(passwordEncoder.encode("default"))
+                .password(passwordEncoder.encode(seedProperties.getDefaultPassword()))
                 .salt(EncryptionUtils.generateSalt())
                 .storageQuota(1L)
                 .build();

--- a/src/main/java/fr/erwil/Spricture/Application/User/Seeding/UserSeedProperties.java
+++ b/src/main/java/fr/erwil/Spricture/Application/User/Seeding/UserSeedProperties.java
@@ -1,0 +1,24 @@
+package fr.erwil.Spricture.Application.User.Seeding;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "user.seed")
+public class UserSeedProperties {
+    private String adminEmail = "admin@example.com";
+    private String adminPassword = generateRandomPassword();
+    private String defaultPassword = generateRandomPassword();
+
+    private static String generateRandomPassword() {
+        SecureRandom random = new SecureRandom();
+        byte[] bytes = new byte[16];
+        random.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,54 @@
+# Application configuration example
+spring.profiles.active=${SPRING_PROFILES_ACTIVE:dev}
+spring.application.name=${SPRING_APPLICATION_NAME:Spricture}
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_DDL_AUTO:create}
+spring.jpa.database-platform=${SPRING_JPA_DATABASE_PLATFORM:org.hibernate.dialect.PostgreSQLDialect}
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/spricture}
+spring.datasource.username=${DB_USER:spricture}
+spring.datasource.password=${DB_PASS:}
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# CORS - Allowed origins for the frontend
+cors.allowed.origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000}
+frontend.host=${FRONTEND_HOST:http://localhost:3000}
+
+# File upload configuration
+spring.servlet.multipart.max-file-size=${MAX_FILE_SIZE:10MB}
+spring.servlet.multipart.max-request-size=${MAX_REQUEST_SIZE:20MB}
+
+# File storage location
+file.storage.location=${FILE_STORAGE_LOCATION:./medias}
+
+# Security Config
+security.jwt.secret-key=${JWT_SECRET:changeme}
+security.jwt.login-expiration-milliseconds=${JWT_LOGIN_EXPIRATION:3600000}
+security.jwt.validate-expiration-milliseconds=${JWT_VALIDATE_EXPIRATION:600000}
+
+logging.level.org.springframework.web=${SPRING_WEB_LOG_LEVEL:DEBUG}
+
+# Mailer
+spring.mail.host=${MAIL_HOST:smtp.gmail.com}
+spring.mail.port=${MAIL_PORT:587}
+spring.mail.username=${MAIL_USER:}
+spring.mail.password=${MAIL_PASS:}
+spring.mail.properties.mail.smtp.auth=${MAIL_SMTP_AUTH:true}
+spring.mail.properties.mail.smtp.starttls.enable=${MAIL_SMTP_STARTTLS:true}
+
+# S3 Storage
+storage.s3.endpoint=${S3_ENDPOINT:https://s3.us-west-004.backblazeb2.com}
+storage.s3.region=${S3_REGION:us-west-004}
+storage.s3.accessKey=${S3_ACCESS_KEY:REPLACE_ME}
+storage.s3.secretKey=${S3_SECRET_KEY:REPLACE_ME}
+storage.s3.bucket=${S3_BUCKET:photone-dev}
+
+# Medium Stat APP user configuration
+medium.stat.app-pseudo=${STAT_APP_PSEUDO:APP_STAT}
+medium.stat.app-password=${STAT_APP_PASSWORD:changeme}
+medium.stat.app-email=${STAT_APP_EMAIL:app_stat@example.com}
+medium.stat.app-quota=${STAT_APP_QUOTA:10}
+medium.stat.quota-threshold-percent=${STAT_QUOTA_THRESHOLD:90}
+
+# User seeding configuration
+user.seed.admin-email=${USER_SEED_ADMIN_EMAIL:admin@example.com}
+user.seed.admin-password=${USER_SEED_ADMIN_PASSWORD:}
+user.seed.default-password=${USER_SEED_DEFAULT_PASSWORD:}

--- a/src/test/java/fr/erwil/Spricture/Application/User/UserServiceTest.java
+++ b/src/test/java/fr/erwil/Spricture/Application/User/UserServiceTest.java
@@ -1,6 +1,7 @@
 package fr.erwil.Spricture.Application.User;
 
 import fr.erwil.Spricture.Application.User.Seeding.UserFactory;
+import fr.erwil.Spricture.Application.User.Seeding.UserSeedProperties;
 import fr.erwil.Spricture.Exceptions.User.UserAccountValidationException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,7 @@ public class UserServiceTest {
     @BeforeEach
     void setup() {
         Mockito.when(encoder.encode(Mockito.anyString())).thenAnswer(invocation -> invocation.getArgument(0));
-        userFactory = new UserFactory(encoder);
+        userFactory = new UserFactory(encoder, new UserSeedProperties());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add default `src/main/resources/application.properties` with environment overrides
- include user seeding properties in application configuration
- track application.properties by adjusting `.gitignore`

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685abbe8a46c832b9f45c0038bf24da1